### PR TITLE
Fix placeholder clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The chapter includes hands-on exercises and examples using real medical imaging 
 
 1. Clone this repository:
 ```bash
-git clone https://github.com/yourusername/AIMI-tutorial.git
+git clone https://github.com/<your-username>/AIMI-tutorial.git
 cd AIMI-tutorial
 ```
 


### PR DESCRIPTION
## Summary
- update README with a generic placeholder for the clone URL

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6842e9d77b28832fa8fd018b9056db31